### PR TITLE
release.sh: eliminate duplicate changes file entry in OBS

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -46,8 +46,6 @@ then
       cpanspec -f *.tar.gz ; \
       echo "Adding new tarball" ; \
       osc add $CPAN_NAME-*.tar.gz ; \
-      echo "Updating changes file" ; \
-      osc vc -m "updated to ${VERSION}\n   see /usr/share/doc/packages/$OBS_NAME/Changes" ; \
       echo "Committing" ; \
       osc -A https://api.opensuse.org/ commit -v -m $VERSION --noservice ; \
       echo "Waiting 10 seconds" ; \


### PR DESCRIPTION
A changes file entry _exactly_ like this one is added when cpanspec is run.

Without this patch, two identical changes file entries are generated when the
release.sh script is run.

Signed-off-by: Nathan Cutler ncutler@suse.com
